### PR TITLE
1時間に一度 cloud run job で処理するところまで

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,15 @@ Set the following in `.env` file:
 # Required
 OPENAI_API_KEY=
 
-# Optional
-GOOGLE_SERVICE_ACCOUNT_KEY_PATH=
+# Optional - Google Service Account Authentication (choose one):
+# Option 1: File path
+GOOGLE_SERVICE_ACCOUNT_KEY_PATH=path/to/service-account-key.json
+
+# Option 2: JSON string
+GOOGLE_SERVICE_ACCOUNT_KEY_JSON='{"type":"service_account","project_id":"..."}'
+
+# Option 3: Base64 encoded JSON (recommended for Cloud Run Jobs)
+GOOGLE_SERVICE_ACCOUNT_KEY_BASE64=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6Li4ufQ==
 
 # Google Drive batch processing folders (both formats supported)
 # Format 1:

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ WHISPER_MODEL=whisper-1
 #### Google Drive API 設定（メイン機能）
 
 ```bash
-# 必須: サービスアカウントキーファイルのパス
-GOOGLE_SERVICE_ACCOUNT_PATH=path/to/service-account-key.json
+# 必須: サービスアカウント認証 (いずれか1つを選択)
+# オプション1: ファイルパス
+GOOGLE_SERVICE_ACCOUNT_KEY_PATH=path/to/service-account-key.json
+# オプション2: JSON文字列
+GOOGLE_SERVICE_ACCOUNT_KEY_JSON='{"type":"service_account","project_id":"..."}'
+# オプション3: Base64エンコードされたJSON (Cloud Run Job推奨)
+GOOGLE_SERVICE_ACCOUNT_KEY_BASE64=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6Li4ufQ==
 
 # 必須: 入力・出力フォルダURL
 INPUT_DRIVE_FOLDER=https://drive.google.com/drive/folders/input_folder_id

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,8 @@ class DIContainer:
         # Google Drive API設定（サービスアカウント）
         # Cloud Runではオプショナル、ローカルでは必須
         self.google_service_account_path = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_PATH")
+        self.google_service_account_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON")  # JSON文字列として直接指定
+        self.google_service_account_base64 = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_BASE64")  # base64エンコードされたJSON
         self.google_drive_upload_folder_id = os.getenv("GOOGLE_DRIVE_UPLOAD_FOLDER_ID")
 
         # Google Driveバッチ処理用（新規追加）
@@ -45,8 +47,12 @@ class DIContainer:
 
         self.chatgpt_client = ChatGPTClient(api_key=self.openai_api_key, model=self.chatgpt_model)
 
-        # Cloud Runでの実行時はADCを使用、ローカルではキーファイルを使用
-        self.google_drive_client = GoogleDriveClient(service_account_path=self.google_service_account_path if self.google_service_account_path else None)
+        # Cloud Runでの実行時はADCを使用、ローカルではキーファイルまたはJSON文字列を使用
+        self.google_drive_client = GoogleDriveClient(
+            service_account_path=self.google_service_account_path if self.google_service_account_path else None,
+            service_account_json=self.google_service_account_json if self.google_service_account_json else None,
+            service_account_base64=self.google_service_account_base64 if self.google_service_account_base64 else None,
+        )
 
         self.prompt_builder = PromptBuilder()
 
@@ -99,7 +105,11 @@ class DIContainer:
             click.echo(f"エラー: 環境変数 {key} が設定されていません", err=True)
             click.echo("以下の環境変数を設定してください:", err=True)
             click.echo("  OPENAI_API_KEY=your_openai_api_key", err=True)
-            click.echo("  GOOGLE_SERVICE_ACCOUNT_PATH=path/to/service-account-key.json", err=True)
+            click.echo("  GOOGLE_SERVICE_ACCOUNT_KEY_PATH=path/to/service-account-key.json", err=True)
+            click.echo("  # または", err=True)
+            click.echo('  GOOGLE_SERVICE_ACCOUNT_KEY_JSON=\'{"type":"service_account","project_id":"..."}\'  # JSON文字列として直接指定', err=True)
+            click.echo("  # または", err=True)
+            click.echo("  GOOGLE_SERVICE_ACCOUNT_KEY_BASE64='eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJv...'  # base64エンコードされたJSON", err=True)
             click.echo("", err=True)
             click.echo("オプション:", err=True)
             click.echo("  CHATGPT_MODEL=gpt-4o  # デフォルト: gpt-4o", err=True)
@@ -193,7 +203,10 @@ def main(
                 sys.exit(1)
 
             if not container.generate_usecase.google_drive_client:
-                click.echo("❌ Google Driveアップロードを使用するには GOOGLE_SERVICE_ACCOUNT_PATH 環境変数を設定してください", err=True)
+                click.echo("❌ Google Driveアップロードを使用するには以下のいずれかの環境変数を設定してください:", err=True)
+                click.echo("  - GOOGLE_SERVICE_ACCOUNT_KEY_PATH (ファイルパス)", err=True)
+                click.echo("  - GOOGLE_SERVICE_ACCOUNT_KEY_JSON (JSON文字列)", err=True)
+                click.echo("  - GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 (base64エンコードされたJSON)", err=True)
                 sys.exit(1)
 
             container.generate_usecase.upload_enabled = True

--- a/terraform/CLAUDE.md
+++ b/terraform/CLAUDE.md
@@ -77,6 +77,7 @@ Each environment has its own:
 - API keys stored in Google Secret Manager
 - Service accounts follow least-privilege principle
 - Separate service accounts for Cloud Build and Cloud Run
+- OpenAI API Key and Slack Webhook URL are automatically created as secrets
 
 ## Important Configuration Variables
 
@@ -96,11 +97,11 @@ memory_limit = "2Gi"
 timeout_seconds = 3600
 schedule = "0 * * * *"  # Cron format
 
-# External Services
-openai_api_key = "sk-..."
+# External Services (stored in Secret Manager)
+openai_api_key = "sk-..."  # Will be stored in Secret Manager
 google_drive_source_folder_url = "https://drive.google.com/..."
 google_drive_destination_folder_url = "https://drive.google.com/..."
-slack_webhook_url = "https://hooks.slack.com/..."
+slack_webhook_url = "https://hooks.slack.com/..."  # Will be stored in Secret Manager
 ```
 
 ## Terraform Cloud Configuration

--- a/terraform/environments/production/.terraform.lock.hcl
+++ b/terraform/environments/production/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Ot05l3dc0NV1m6kj9RmHVwh04GPZPGF/FZjlxG7npIQ=",
+    "zh:2c19e507d0cb1c090b852b165546e944b8f170f2a8008194327a549a221f7401",
+    "zh:301dae4d16f4ee6d69d3c15cfc512fb43dfbe4f4e4dda770690a83f5b5a3a3d8",
+    "zh:462b7595e7f6b4d99c28a4dea53a670403848e92cce3d285f46348b133fbb147",
+    "zh:497ccc6eb271b5de5b1f6f27e9628a44f389c9bc3d882a64364eb193a75a7810",
+    "zh:55470b414159e65aef941b4f44950c550f813507ced53838c691362c97a7017d",
+    "zh:5ca738d8f78ab767ab83bd68aa69c2954ba0530ee8f85142cda7aba77639af33",
+    "zh:676e1bfe0369dc9fa19ada9b7fc1295c51e4531b112f4827788dfabfa7384c96",
+    "zh:88250b4c2b4d1c6a4209b3c6addfcff8a987b34e212ee6488cb3d95f02cdfc84",
+    "zh:8849ccae5a741dde389a3f6d85fff440b13dee0fd4a074b23837cbb6e82fb71e",
+    "zh:93a0255e34928f71d9bc5c50510e4ee79376ac2cd671e35e707041d16a92030c",
+    "zh:99034905632982b6a577df80d0ef8974a5f4a8edaa80652c6217b3bb4c5ce27c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Bj4QY6v5W0PF1Fx8LlnSZuwmEmwPA15wpoDWo/7+hDw=",
+    "zh:0e3cc3a10c0007d70e600e430178e62fbc8e35ecd8b93fdeda0b563e5fe58882",
+    "zh:14e449b275f9ac59b7e5807b26b88b22c33bb0bda54eed8d48b885320e6c9f64",
+    "zh:33b56c7c324a82fc34c900eeb3246b793dbead57f78282f2797aa5fe231d6031",
+    "zh:43bd87c74f909bf4053cd9cfff1a5e6146858233bd057171e4ff98ae4182be82",
+    "zh:8128f14dcb5f8a263d7855d81180538cb1bc28765cb2f882a9561d7dcaf65c47",
+    "zh:8168fa443890bed13f679ae6f634334e07ba83b24fadb2d0ba0b0e02aa7ec4d3",
+    "zh:8728574057ddc05ad163604a5950bc467c978aa06ca3322317bc0fa548ac304a",
+    "zh:97957dad2b06812b9154fb5cc6143688e1840684c5319bfd502f994dd79112d4",
+    "zh:a1ba523ca7d60dc67183082303783014c5a4a57e665c75d852f9fed474f30fbb",
+    "zh:c70807412f68837793ae87a6d18efb9f97a6f76304cdd74fdf62d7da3beec4cc",
+    "zh:ef05ddfe4917e08f465e05df159e68860ce1c617d41fd13999f9b925655be71f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -35,6 +35,17 @@ module "service_account" {
   service_name = "${local.app_name}-${local.environment}"
 }
 
+# Secret Manager for API keys
+module "secret_manager" {
+  source = "../../modules/secret_manager"
+
+  project_id        = var.project_id
+  app_name          = local.app_name
+  environment       = local.environment
+  openai_api_key    = var.openai_api_key
+  slack_webhook_url = var.slack_webhook_url
+}
+
 # Cloud Run Job
 module "cloud_run_job" {
   source = "../../modules/cloud_run_job"
@@ -46,13 +57,13 @@ module "cloud_run_job" {
   cpu_limit                           = var.cpu_limit
   memory_limit                        = var.memory_limit
   timeout_seconds                     = var.timeout_seconds
-  openai_api_key                      = var.openai_api_key
+  openai_api_key_secret_id            = module.secret_manager.openai_api_key_secret_id
   service_account_key_base64          = module.service_account.service_account_key
   google_drive_source_folder_url      = var.google_drive_source_folder_url
   google_drive_destination_folder_url = var.google_drive_destination_folder_url
-  slack_webhook_url                   = var.slack_webhook_url
+  slack_webhook_secret_id             = module.secret_manager.slack_webhook_secret_id
 
-  depends_on = [module.artifact_registry]
+  depends_on = [module.artifact_registry, module.secret_manager]
 }
 
 # Cloud Scheduler for periodic execution

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -27,3 +27,45 @@ module "cloud_build" {
   artifact_registry_repository      = module.artifact_registry.repository_id
 }
 
+# Service Account for Google Drive access
+module "service_account" {
+  source = "../../modules/service_account"
+
+  project_id   = var.project_id
+  service_name = "${local.app_name}-${local.environment}"
+}
+
+# Cloud Run Job
+module "cloud_run_job" {
+  source = "../../modules/cloud_run_job"
+
+  project_id                          = var.project_id
+  region                              = var.region
+  service_name                        = "${local.app_name}-${local.environment}"
+  container_image                     = "${var.region}-docker.pkg.dev/${var.project_id}/${module.artifact_registry.repository_id}/${local.app_name}:latest"
+  cpu_limit                           = var.cpu_limit
+  memory_limit                        = var.memory_limit
+  timeout_seconds                     = var.timeout_seconds
+  openai_api_key                      = var.openai_api_key
+  service_account_key_base64          = module.service_account.service_account_key
+  google_drive_source_folder_url      = var.google_drive_source_folder_url
+  google_drive_destination_folder_url = var.google_drive_destination_folder_url
+  slack_webhook_url                   = var.slack_webhook_url
+
+  depends_on = [module.artifact_registry]
+}
+
+# Cloud Scheduler for periodic execution
+module "cloud_scheduler_job" {
+  source = "../../modules/cloud_scheduler_job"
+
+  project_id         = var.project_id
+  region             = var.region
+  service_name       = "${local.app_name}-${local.environment}"
+  cloud_run_job_name = module.cloud_run_job.job_name
+  schedule           = var.schedule
+  time_zone          = var.time_zone
+
+  depends_on = [module.cloud_run_job]
+}
+

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -5,3 +5,17 @@ region                            = "asia-northeast1"
 github_app_installation_id        = 123456789  # Your GitHub App installation ID
 github_oauth_token_secret_version = "projects/PROJECT_ID/secrets/github-token/versions/latest"
 trigger_branch                    = "^main$"  # Branch pattern to trigger Cloud Build
+
+# Cloud Run configuration
+cpu_limit              = "2000m"
+memory_limit           = "2Gi"
+timeout_seconds        = 3600
+schedule               = "0 * * * *"  # Every hour
+time_zone              = "Asia/Tokyo"
+
+# API Keys and External Services
+# These values will be stored in Google Secret Manager
+openai_api_key                      = "sk-..." # Your OpenAI API key
+google_drive_source_folder_url      = "https://drive.google.com/drive/folders/SOURCE_FOLDER_ID"
+google_drive_destination_folder_url = "https://drive.google.com/drive/folders/DESTINATION_FOLDER_ID"
+slack_webhook_url                   = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -23,3 +23,55 @@ variable "trigger_branch" {
   description = "Branch pattern to trigger Cloud Build"
   type        = string
 }
+
+variable "cpu_limit" {
+  description = "CPU limit for the container"
+  type        = string
+  default     = "2000m"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the container"
+  type        = string
+  default     = "2Gi"
+}
+
+variable "timeout_seconds" {
+  description = "Timeout for the Cloud Run service in seconds"
+  type        = number
+  default     = 3600
+}
+
+variable "schedule" {
+  description = "Cron schedule expression (every hour by default)"
+  type        = string
+  default     = "0 * * * *"
+}
+
+variable "time_zone" {
+  description = "Time zone for the scheduler"
+  type        = string
+  default     = "Asia/Tokyo"
+}
+
+variable "openai_api_key" {
+  description = "OpenAI API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "google_drive_source_folder_url" {
+  description = "Google Drive source folder URL (where videos are stored)"
+  type        = string
+}
+
+variable "google_drive_destination_folder_url" {
+  description = "Google Drive destination folder URL (where results are saved)"
+  type        = string
+}
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -35,6 +35,17 @@ module "service_account" {
   service_name = "${local.app_name}-${local.environment}"
 }
 
+# Secret Manager for API keys
+module "secret_manager" {
+  source = "../../modules/secret_manager"
+
+  project_id        = var.project_id
+  app_name          = local.app_name
+  environment       = local.environment
+  openai_api_key    = var.openai_api_key
+  slack_webhook_url = var.slack_webhook_url
+}
+
 # Cloud Run Job
 module "cloud_run_job" {
   source = "../../modules/cloud_run_job"
@@ -46,13 +57,13 @@ module "cloud_run_job" {
   cpu_limit                           = var.cpu_limit
   memory_limit                        = var.memory_limit
   timeout_seconds                     = var.timeout_seconds
-  openai_api_key                      = var.openai_api_key
+  openai_api_key_secret_id            = module.secret_manager.openai_api_key_secret_id
   service_account_key_base64          = module.service_account.service_account_key
   google_drive_source_folder_url      = var.google_drive_source_folder_url
   google_drive_destination_folder_url = var.google_drive_destination_folder_url
-  slack_webhook_url                   = var.slack_webhook_url
+  slack_webhook_secret_id             = module.secret_manager.slack_webhook_secret_id
 
-  depends_on = [module.artifact_registry]
+  depends_on = [module.artifact_registry, module.secret_manager]
 }
 
 # Cloud Scheduler for periodic execution

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -30,7 +30,7 @@ module "cloud_build" {
 # Service Account for Google Drive access
 module "service_account" {
   source = "../../modules/service_account"
-  
+
   project_id   = var.project_id
   service_name = "${local.app_name}-${local.environment}"
 }
@@ -38,34 +38,34 @@ module "service_account" {
 # Cloud Run Job
 module "cloud_run_job" {
   source = "../../modules/cloud_run_job"
-  
-  project_id               = var.project_id
-  region                   = var.region
-  service_name             = "${local.app_name}-${local.environment}"
-  container_image          = "${var.region}-docker.pkg.dev/${var.project_id}/${module.artifact_registry.repository_id}/${local.app_name}:latest"
-  cpu_limit                = var.cpu_limit
-  memory_limit             = var.memory_limit
-  timeout_seconds          = var.timeout_seconds
-  openai_api_key           = var.openai_api_key
-  service_account_key_json = module.service_account.service_account_key
+
+  project_id                          = var.project_id
+  region                              = var.region
+  service_name                        = "${local.app_name}-${local.environment}"
+  container_image                     = "${var.region}-docker.pkg.dev/${var.project_id}/${module.artifact_registry.repository_id}/${local.app_name}:latest"
+  cpu_limit                           = var.cpu_limit
+  memory_limit                        = var.memory_limit
+  timeout_seconds                     = var.timeout_seconds
+  openai_api_key                      = var.openai_api_key
+  service_account_key_base64          = module.service_account.service_account_key
   google_drive_source_folder_url      = var.google_drive_source_folder_url
   google_drive_destination_folder_url = var.google_drive_destination_folder_url
-  slack_webhook_url        = var.slack_webhook_url
-  
+  slack_webhook_url                   = var.slack_webhook_url
+
   depends_on = [module.artifact_registry]
 }
 
 # Cloud Scheduler for periodic execution
 module "cloud_scheduler_job" {
   source = "../../modules/cloud_scheduler_job"
-  
+
   project_id         = var.project_id
   region             = var.region
   service_name       = "${local.app_name}-${local.environment}"
   cloud_run_job_name = module.cloud_run_job.job_name
   schedule           = var.schedule
   time_zone          = var.time_zone
-  
+
   depends_on = [module.cloud_run_job]
 }
 

--- a/terraform/environments/staging/terraform.tfvars.example
+++ b/terraform/environments/staging/terraform.tfvars.example
@@ -14,7 +14,8 @@ schedule               = "0 * * * *"  # Every hour
 time_zone              = "Asia/Tokyo"
 
 # API Keys and External Services
-openai_api_key                      = "your-openai-api-key"
+# These values will be stored in Google Secret Manager
+openai_api_key                      = "sk-..." # Your OpenAI API key
 google_drive_source_folder_url      = "https://drive.google.com/drive/folders/SOURCE_FOLDER_ID"
 google_drive_destination_folder_url = "https://drive.google.com/drive/folders/DESTINATION_FOLDER_ID"
-slack_webhook_url                   = "your-slack-webhook-url"
+slack_webhook_url                   = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"

--- a/terraform/modules/cloud-build/main.tf
+++ b/terraform/modules/cloud-build/main.tf
@@ -16,7 +16,7 @@ resource "google_project_iam_member" "cloud_build_permissions" {
     "roles/run.admin",
     "roles/iam.serviceAccountUser"
   ])
-  
+
   project = var.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.cloud_build.email}"

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -6,7 +6,7 @@ resource "google_cloud_run_service" "shortmovie_generator" {
     spec {
       containers {
         image = var.container_image
-        
+
         resources {
           limits = {
             cpu    = var.cpu_limit

--- a/terraform/modules/cloud_run_job/main.tf
+++ b/terraform/modules/cloud_run_job/main.tf
@@ -1,3 +1,21 @@
+# Google Driveサービスアカウントキーを保存するシークレット
+resource "google_secret_manager_secret" "service_account_key" {
+  project   = var.project_id
+  secret_id = "${var.service_name}-service-account-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+# シークレットのバージョン（実際のキーデータ）
+resource "google_secret_manager_secret_version" "service_account_key" {
+  secret      = google_secret_manager_secret.service_account_key.id
+  secret_data = var.service_account_key_base64
+}
+
 resource "google_cloud_run_v2_job" "shortmovie_generator" {
   name     = var.service_name
   location = var.region
@@ -8,7 +26,7 @@ resource "google_cloud_run_v2_job" "shortmovie_generator" {
       containers {
         image = var.container_image
         args  = ["python", "-m", "src.main", "--drive-batch"]
-        
+
         resources {
           limits = {
             cpu    = var.cpu_limit
@@ -22,8 +40,13 @@ resource "google_cloud_run_v2_job" "shortmovie_generator" {
         }
 
         env {
-          name  = "GOOGLE_SERVICE_ACCOUNT_KEY_PATH"
-          value = "/secrets/service-account-key.json"
+          name = "GOOGLE_SERVICE_ACCOUNT_KEY_BASE64"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.service_account_key.secret_id
+              version = "latest"
+            }
+          }
         }
 
         env {
@@ -41,32 +64,17 @@ resource "google_cloud_run_v2_job" "shortmovie_generator" {
           value = var.slack_webhook_url
         }
 
-        volume_mounts {
-          name       = "service-account-key"
-          mount_path = "/secrets"
-        }
       }
 
-      volumes {
-        name = "service-account-key"
-        secret {
-          secret = google_secret_manager_secret.service_account_key.secret_id
-          items {
-            version = "latest"
-            path    = "service-account-key.json"
-          }
-        }
-      }
-
-      timeout           = "${var.timeout_seconds}s"
-      service_account   = google_service_account.cloud_run_sa.email
-      max_retries       = 1
+      timeout         = "${var.timeout_seconds}s"
+      service_account = google_service_account.cloud_run_sa.email
+      max_retries     = 1
     }
   }
 
   depends_on = [
     google_project_service.cloud_run_api,
-    google_secret_manager_secret_version.service_account_key_version
+    google_secret_manager_secret_version.service_account_key
   ]
 }
 
@@ -74,22 +82,6 @@ resource "google_service_account" "cloud_run_sa" {
   account_id   = "${var.service_name}-sa"
   display_name = "Service Account for ${var.service_name}"
   project      = var.project_id
-}
-
-resource "google_secret_manager_secret" "service_account_key" {
-  secret_id = "${var.service_name}-service-account-key"
-  project   = var.project_id
-
-  replication {
-    auto {}
-  }
-
-  depends_on = [google_project_service.secretmanager_api]
-}
-
-resource "google_secret_manager_secret_version" "service_account_key_version" {
-  secret      = google_secret_manager_secret.service_account_key.id
-  secret_data = var.service_account_key_json
 }
 
 resource "google_secret_manager_secret_iam_member" "cloud_run_secret_accessor" {

--- a/terraform/modules/cloud_run_job/main.tf
+++ b/terraform/modules/cloud_run_job/main.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_job" "shortmovie_generator" {
     template {
       containers {
         image = var.container_image
-        args  = ["python", "-m", "src.main", "--drive"]
+        args  = ["python", "-m", "src.main", "--drive-batch"]
         
         resources {
           limits = {

--- a/terraform/modules/cloud_run_job/main.tf
+++ b/terraform/modules/cloud_run_job/main.tf
@@ -7,6 +7,7 @@ resource "google_cloud_run_v2_job" "shortmovie_generator" {
     template {
       containers {
         image = var.container_image
+        args  = ["python", "-m", "src.main", "--drive"]
         
         resources {
           limits = {

--- a/terraform/modules/cloud_run_job/variables.tf
+++ b/terraform/modules/cloud_run_job/variables.tf
@@ -36,10 +36,9 @@ variable "timeout_seconds" {
   default     = 3600
 }
 
-variable "openai_api_key" {
-  description = "OpenAI API key"
+variable "openai_api_key_secret_id" {
+  description = "Secret Manager secret ID for OpenAI API key"
   type        = string
-  sensitive   = true
 }
 
 variable "service_account_key_base64" {
@@ -58,8 +57,7 @@ variable "google_drive_destination_folder_url" {
   type        = string
 }
 
-variable "slack_webhook_url" {
-  description = "Slack webhook URL"
+variable "slack_webhook_secret_id" {
+  description = "Secret Manager secret ID for Slack webhook URL"
   type        = string
-  sensitive   = true
 }

--- a/terraform/modules/cloud_run_job/variables.tf
+++ b/terraform/modules/cloud_run_job/variables.tf
@@ -42,8 +42,8 @@ variable "openai_api_key" {
   sensitive   = true
 }
 
-variable "service_account_key_json" {
-  description = "Service account key JSON content"
+variable "service_account_key_base64" {
+  description = "Base64-encoded service account key JSON for Google Drive access"
   type        = string
   sensitive   = true
 }

--- a/terraform/modules/cloud_scheduler/main.tf
+++ b/terraform/modules/cloud_scheduler/main.tf
@@ -9,7 +9,7 @@ resource "google_cloud_scheduler_job" "shortmovie_generator_job" {
   http_target {
     http_method = "POST"
     uri         = "${var.cloud_run_url}/batch-process"
-    
+
     headers = {
       "Content-Type" = "application/json"
     }

--- a/terraform/modules/cloud_scheduler_job/main.tf
+++ b/terraform/modules/cloud_scheduler_job/main.tf
@@ -9,7 +9,7 @@ resource "google_cloud_scheduler_job" "shortmovie_generator_job" {
   http_target {
     http_method = "POST"
     uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${var.cloud_run_job_name}:run"
-    
+
     oauth_token {
       service_account_email = google_service_account.scheduler_sa.email
       scope                 = "https://www.googleapis.com/auth/cloud-platform"

--- a/terraform/modules/secret_manager/main.tf
+++ b/terraform/modules/secret_manager/main.tf
@@ -1,0 +1,41 @@
+# Enable Secret Manager API
+resource "google_project_service" "secretmanager_api" {
+  project = var.project_id
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# OpenAI API Key Secret
+resource "google_secret_manager_secret" "openai_api_key" {
+  project   = var.project_id
+  secret_id = "${var.app_name}-${var.environment}-openai-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+resource "google_secret_manager_secret_version" "openai_api_key" {
+  secret      = google_secret_manager_secret.openai_api_key.id
+  secret_data = var.openai_api_key
+}
+
+# Slack Webhook URL Secret  
+resource "google_secret_manager_secret" "slack_webhook_url" {
+  project   = var.project_id
+  secret_id = "${var.app_name}-${var.environment}-slack-webhook-url"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+resource "google_secret_manager_secret_version" "slack_webhook_url" {
+  secret      = google_secret_manager_secret.slack_webhook_url.id
+  secret_data = var.slack_webhook_url
+}

--- a/terraform/modules/secret_manager/outputs.tf
+++ b/terraform/modules/secret_manager/outputs.tf
@@ -1,0 +1,9 @@
+output "openai_api_key_secret_id" {
+  description = "The secret ID for OpenAI API key"
+  value       = google_secret_manager_secret.openai_api_key.id
+}
+
+output "slack_webhook_secret_id" {
+  description = "The secret ID for Slack webhook URL"
+  value       = google_secret_manager_secret.slack_webhook_url.id
+}

--- a/terraform/modules/secret_manager/variables.tf
+++ b/terraform/modules/secret_manager/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Name of the application"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (staging, production)"
+  type        = string
+}
+
+variable "openai_api_key" {
+  description = "OpenAI API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/modules/service_account/outputs.tf
+++ b/terraform/modules/service_account/outputs.tf
@@ -4,7 +4,7 @@ output "service_account_email" {
 }
 
 output "service_account_key" {
-  description = "Service account key"
+  description = "Base64-encoded service account key"
   value       = google_service_account_key.drive_access_key.private_key
   sensitive   = true
 }


### PR DESCRIPTION
# 変更の概要
- 環境変数等を整備して cloud run job で起動するようにした
   - https://console.cloud.google.com/run/jobs/details/asia-northeast1/sm-draft-staging/executions?hl=ja&inv=1&invt=Ab2iPA&project=shortmovie-draft-generator

動いていることは確認

<img width="772" height="177" alt="スクリーンショット 2025-07-12 16 15 37" src="https://github.com/user-attachments/assets/854a54fc-3c12-4225-8f5d-862cf2be5dea" />


# 変更の背景
- 


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました
